### PR TITLE
Removed default value from FB Pixel Option

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -225,8 +225,7 @@
     {
       "type": "text",
       "id": "signup_fb_pixel",
-      "label": "FB Pixel ID",
-      "default": ""
+      "label": "FB Pixel ID"
     }
   ]
 }


### PR DESCRIPTION
I got an error in quickshot that said:

```
Error in config/settings_schema.json - Section 18: setting with id="signup_fb_pixel" default can't be blank
```

So I'm removing that default section so the settings file can be uploaded.